### PR TITLE
clarify scope requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
-The format is a space separated list of strings from Coinbase's [list of OAuth Permissions](https://coinbase.com/docs/api/authentication#permissions). If you don't include any `scope` it will default to `all`.
+The format is a space separated list of strings from Coinbase's [list of OAuth Permissions](https://coinbase.com/docs/api/authentication#permissions). Remember that at minimum you MUST include either the 'all' or 'user' scopes.
 
-NOTE: While developing your application, if you change the scope in the initializer you will need to restart your app server. Remember that at minimum you MUST include either the 'all' or 'user' scopes.
+NOTE: While developing your application, if you change the scope in the initializer you will need to restart your app server.


### PR DESCRIPTION
 "If you don't include any `scope` it will default to `all`." contradicts with "Remember that at minimum you MUST include either the 'all' or 'user' scopes."

If you don't include any scope then authentication fails.   "If you don't include any `scope` it will default to `all`." makes it sound like not initializing the scope will still work.